### PR TITLE
:tokyo_tower: Tower Extension Implementation

### DIFF
--- a/src/gadgets/curves/bn256/ec_pairing.rs
+++ b/src/gadgets/curves/bn256/ec_pairing.rs
@@ -2,7 +2,10 @@ use std::sync::Arc;
 
 use pairing::{bn256::G2Affine as BN256G2Affine, GenericCurveAffine};
 
-use crate::{cs::traits::cs::ConstraintSystem, gadgets::{curves::SmallField, non_native_field::traits::CurveCompatibleNonNativeField}};
+use crate::{
+    cs::traits::cs::ConstraintSystem,
+    gadgets::{curves::SmallField, non_native_field::traits::CurveCompatibleNonNativeField},
+};
 
 use super::*;
 
@@ -178,4 +181,50 @@ where
             _marker: std::marker::PhantomData::<CS>,
         }
     }
+}
+
+pub struct FinalExpEvaluation<F, CS>
+where
+    F: SmallField,
+    CS: ConstraintSystem<F>,
+{
+    resultant_f: BN256Fq12NNField<F>,
+    _marker: std::marker::PhantomData<CS>,
+}
+
+impl<F, CS> FinalExpEvaluation<F, CS>
+where
+    F: SmallField,
+    CS: ConstraintSystem<F>,
+{
+    pub fn evaluate(cs: &mut CS, f: &mut BN256Fq12NNField<F>) -> Self {
+        let mut easy_part_f = Self::easy_part(cs, f);
+        let hard_part = Self::hard_part(cs, &mut easy_part_f);
+        Self {
+            resultant_f: hard_part,
+            _marker: std::marker::PhantomData::<CS>,
+        }
+    }
+
+    pub fn easy_part(cs: &mut CS, f: &mut BN256Fq12NNField<F>) -> BN256Fq12NNField<F> {
+        todo!();
+    }
+
+    pub fn hard_part(cs: &mut CS, f: &mut BN256Fq12NNField<F>) -> BN256Fq12NNField<F> {
+        todo!();
+    }
+}
+
+pub fn ec_mul<F, CS>(
+    cs: &mut CS,
+    p: &mut BN256SWProjectivePoint<F>,
+    q: &mut BN256SWProjectivePointTwisted<F>,
+) -> BN256Fq12NNField<F>
+where
+    F: SmallField,
+    CS: ConstraintSystem<F>,
+{
+    let mut miller_loop = MillerLoopEvaluation::evaluate(cs, p, q);
+    let final_exp = FinalExpEvaluation::evaluate(cs, &mut miller_loop.accumulated_f);
+    final_exp.resultant_f
 }

--- a/src/gadgets/curves/bn256/ec_pairing.rs
+++ b/src/gadgets/curves/bn256/ec_pairing.rs
@@ -207,9 +207,19 @@ where
     }
 
     pub fn easy_part(cs: &mut CS, f: &mut BN256Fq12NNField<F>) -> BN256Fq12NNField<F> {
-        todo!();
+        // f1 <- f^(p^6 - 1)
+        let mut f1 = f.inverse(cs);
+        let mut fp6 = f.frobenius_map(cs, 6);
+        let mut f1 = f1.mul(cs, &mut fp6);
+    
+        // f2 <- f1^(p^2 + 1)
+        let mut fp2 = f1.frobenius_map(cs, 2);
+        let f2 = f1.mul(cs, &mut fp2);
+
+        f2
     }
 
+    #[allow(unused_variables)]
     pub fn hard_part(cs: &mut CS, f: &mut BN256Fq12NNField<F>) -> BN256Fq12NNField<F> {
         todo!();
     }

--- a/src/gadgets/curves/bn256/ec_pairing.rs
+++ b/src/gadgets/curves/bn256/ec_pairing.rs
@@ -28,8 +28,8 @@ where
     CS: ConstraintSystem<F>,
 {
     c0: BN256Fq2NNField<F>,
-    c1: BN256Fq2NNField<F>,
-    c2: BN256Fq2NNField<F>,
+    c3: BN256Fq2NNField<F>,
+    c4: BN256Fq2NNField<F>,
     _marker: std::marker::PhantomData<CS>,
 }
 
@@ -38,21 +38,33 @@ where
     F: SmallField,
     CS: ConstraintSystem<F>,
 {
-    pub fn new(cs: &mut CS, params: &Arc<BN256BaseNNFieldParams>) -> Self {
+    /// Creates a new instance of the line function evaluation for the BN256 curve.
+    pub fn new(c0: BN256Fq2NNField<F>, c3: BN256Fq2NNField<F>, c4: BN256Fq2NNField<F>) -> Self {
+        Self {
+            c0,
+            c3,
+            c4,
+            _marker: std::marker::PhantomData::<CS>,
+        }
+    }
+
+    /// Creates a zero instance of the line function evaluation for the BN256 curve.
+    pub fn zero(cs: &mut CS, params: &Arc<BN256BaseNNFieldParams>) -> Self {
         Self {
             c0: BN256Fq2NNField::zero(cs, params),
-            c1: BN256Fq2NNField::zero(cs, params),
-            c2: BN256Fq2NNField::zero(cs, params),
+            c3: BN256Fq2NNField::zero(cs, params),
+            c4: BN256Fq2NNField::zero(cs, params),
             _marker: std::marker::PhantomData::<CS>,
         }
     }
 
     /// This function computes the line function evaluation for the BN256 curve
-    /// `l_{P,Q}(R)` when `P` and `Q` are distinct points on the twisted curve
-    /// `E'(F_{p^2})` and `R` is a point on the regular curve `E(F_p)`.
+    /// `L_{P,Q}(R)` when `P` and `Q` are distinct points on the twisted curve
+    /// `E'(F_{p^2})` and `R` is a point on the regular curve `E(F_p)`. For details, 
+    /// see _Section 3_ in https://eprint.iacr.org/2019/077.pdf.
     #[allow(non_snake_case)]
     pub fn at_line(
-        mut self,
+        &mut self,
         cs: &mut CS,
         point1: &mut BN256SWProjectivePointTwisted<F>,
         point2: &mut BN256SWProjectivePointTwisted<F>,
@@ -63,29 +75,27 @@ where
         let mut x_sub_z_x2 = point2.x.sub(cs, &mut z_x2);
         let c0 = x_sub_z_x2.mul_c0(cs, &mut at.y);
 
-        // c1 <- (Y - Z * Y2) * X2 - (X - Z * X2) * Y2
+        // c4 <- (Y - Z * Y2) * X2 - (X - Z * X2) * Y2
         let mut z_y2 = point2.z.mul(cs, &mut point1.y);
         let mut y_sub_z_y2 = point2.y.sub(cs, &mut z_y2);
-        let mut c1 = point1.x.mul(cs, &mut y_sub_z_y2);
+        let mut c4 = point1.x.mul(cs, &mut y_sub_z_y2);
         let mut y2_x_sub_z_x2 = point1.y.mul(cs, &mut x_sub_z_x2);
-        let c1 = c1.sub(cs, &mut y2_x_sub_z_x2);
+        let c4 = c4.sub(cs, &mut y2_x_sub_z_x2);
 
-        // c2 <- -(Y - Z * Y2) * x_P
-        let mut c2 = y_sub_z_y2.negated(cs);
-        let c2 = c2.mul_c0(cs, &mut at.x);
+        // c3 <- -(Y - Z * Y2) * x_P
+        let mut c3 = y_sub_z_y2.negated(cs);
+        let c3 = c3.mul_c0(cs, &mut at.x);
 
-        self.c0 = c0;
-        self.c1 = c1;
-        self.c2 = c2;
-        self
+        Self::new(c0, c3, c4)
     }
 
     /// This function computes the line function evaluation for the BN256 curve
-    /// `l_{P,P}(R)` when `P` is a point on the twisted curve `E'(F_{p^2})` and
-    /// `R` is a point on the regular curve `E(F_p)`.
+    /// `L_{P,P}(R)` when `P` is a point on the twisted curve `E'(F_{p^2})` and
+    /// `R` is a point on the regular curve `E(F_p)`. For details, 
+    /// see _Section 3_ in https://eprint.iacr.org/2019/077.pdf.
     #[allow(non_snake_case)]
     pub fn at_tangent(
-        mut self,
+        &mut self,
         cs: &mut CS,
         point: &mut BN256SWProjectivePointTwisted<F>,
         at: &mut BN256SWProjectivePoint<F>,
@@ -100,31 +110,27 @@ where
         let mut c0 = c0.double(cs);
         let c0 = c0.negated(cs);
 
-        // c1 <- 3b' * Z^2 - Y^2
+        // c4 <- 3b' * Z^2 - Y^2
         let mut z2 = point.z.square(cs);
         let mut z2 = z2.mul(cs, &mut b_twist);
-        let mut c1 = z2.double(cs);
-        let mut c1 = c1.add(cs, &mut z2);
+        let mut c4 = z2.double(cs);
+        let mut c4 = c4.add(cs, &mut z2);
         let mut y2 = point.y.square(cs);
-        let c1 = c1.sub(cs, &mut y2);
+        let c4 = c4.sub(cs, &mut y2);
 
-        // c2 <- 3 * X^2 * x_P
+        // c3 <- 3 * X^2 * x_P
         let mut x2 = point.x.square(cs);
-        let mut c2 = x2.mul_c0(cs, &mut at.x);
-        let mut c2 = c2.double(cs);
-        let c2 = c2.add(cs, &mut x2);
+        let mut c3 = x2.mul_c0(cs, &mut at.x);
+        let mut c3 = c3.double(cs);
+        let c3 = c3.add(cs, &mut x2);
 
-        self.c0 = c0;
-        self.c1 = c1;
-        self.c2 = c2;
-        self
-    }
-
-    pub fn as_tuple(&self) -> (BN256Fq2NNField<F>, BN256Fq2NNField<F>, BN256Fq2NNField<F>) {
-        (self.c0.clone(), self.c1.clone(), self.c2.clone())
+        Self::new(c0, c3, c4)
     }
 }
 
+/// Struct for the miller loop evaluation for the BN256 curve.
+/// Here, the Miller loop returns the accumulated f value after the loop
+/// without the final exponentiation.
 pub struct MillerLoopEvaluation<F, CS>
 where
     F: SmallField,
@@ -139,48 +145,59 @@ where
     F: SmallField,
     CS: ConstraintSystem<F>,
 {
-    #[allow(non_snake_case)]
+    /// This function computes the Miller loop for the BN256 curve, using 
+    /// algorithm from _Section 2_ from https://eprint.iacr.org/2016/130.pdf.
     pub fn evaluate(
         cs: &mut CS,
         p: &mut BN256SWProjectivePoint<F>,
         q: &mut BN256SWProjectivePointTwisted<F>,
     ) -> Self {
+        // Setting evaluation parameters
         let params = p.x.params.clone();
+        let mut evaluation = LineFunctionEvaluation::zero(cs, &params);
+
         let mut f1 = BN256Fq12NNField::one(cs, &params);
         let mut r = q.clone();
 
         for u in CURVE_PARAMETER_WNAF {
-            let tangent_fn = LineFunctionEvaluation::new(cs, &params).at_tangent(cs, &mut r, p);
-            let (mut c0, mut c1, mut c4) = tangent_fn.as_tuple();
+            // Doubling step: f1 <- f1^2 * L_{R,R}(P), R <- 2R
+            let mut tan_fn = evaluation.at_tangent(cs, &mut r, p);
             f1 = f1.square(cs);
-            f1 = f1.mul_by_c0c1c4(cs, &mut c0, &mut c1, &mut c4);
+            f1 = Self::mul_f12_by_line_fn(cs, &mut f1, &mut tan_fn);
             r = r.double(cs);
 
-            if u == 1 {
-                let line_fn = LineFunctionEvaluation::new(cs, &params).at_line(cs, &mut r, q, p);
-                let (mut c0, mut c1, mut c4) = line_fn.as_tuple();
-                f1 = f1.mul_by_c0c1c4(cs, &mut c0, &mut c1, &mut c4);
-
-                let qx = q.x.clone();
-                let qy = q.y.clone();
-                r = r.add_mixed(cs, &mut (qx, qy));
+            // Skip if u is zero
+            if u == 0 {
+                continue;
             }
+
+            // Addition step: f1 <- f1 * L_{R,Q}(P), R <- R + Q.
+            // If u is negative, negate Q.
+            let mut q = q.clone();
             if u == -1 {
-                *q = q.negated(cs);
-                let line_fn = LineFunctionEvaluation::new(cs, &params).at_line(cs, &mut r, q, p);
-                let (mut c0, mut c1, mut c4) = line_fn.as_tuple();
-                f1 = f1.mul_by_c0c1c4(cs, &mut c0, &mut c1, &mut c4);
-
-                let qx = q.x.clone();
-                let qy = q.y.clone();
-                r = r.sub_mixed(cs, &mut (qx, qy));
+                q = q.negated(cs);
             }
+
+            let mut line_fn = evaluation.at_line(cs, &mut r, &mut q, p);
+            f1 = Self::mul_f12_by_line_fn(cs, &mut f1, &mut line_fn);
+
+            let qx = q.x.clone();
+            let qy = q.y.clone();
+            r = r.add_mixed(cs, &mut (qx, qy));
         }
 
         Self {
             accumulated_f: f1,
             _marker: std::marker::PhantomData::<CS>,
         }
+    }
+
+    fn mul_f12_by_line_fn(
+        cs: &mut CS,
+        f: &mut BN256Fq12NNField<F>,
+        line_fn: &mut LineFunctionEvaluation<F, CS>,
+    ) -> BN256Fq12NNField<F> {
+        f.mul_by_c0c3c4(cs, &mut line_fn.c0, &mut line_fn.c3, &mut line_fn.c4)
     }
 }
 
@@ -270,6 +287,7 @@ where
     }
 }
 
+/// This function computes the pairing function for the BN256 curve.
 pub fn ec_mul<F, CS>(
     cs: &mut CS,
     p: &mut BN256SWProjectivePoint<F>,

--- a/src/gadgets/curves/bn256/ec_pairing.rs
+++ b/src/gadgets/curves/bn256/ec_pairing.rs
@@ -138,7 +138,6 @@ where
     }
 }
 
-
 pub struct MillerLoopEvaluation<F, T, NN, CS>
 where
     F: SmallField,

--- a/src/gadgets/curves/bn256/mod.rs
+++ b/src/gadgets/curves/bn256/mod.rs
@@ -2,8 +2,8 @@ use super::curves::non_native_field::implementations::{
     NonNativeFieldOverU16, NonNativeFieldOverU16Params,
 };
 use super::sw_projective::SWProjectivePoint;
-use super::tower_extension::fp12::Fp12;
-use crate::gadgets::tower_extension::fp2::Fp2;
+use super::tower_extension::params::bn256::{BN256Extension12Params, BN256Extension2Params};
+use super::tower_extension::{fp12::Fp12, fp2::Fp2};
 
 // Characteristic of the base field for bn256 curve
 use pairing::bn256::fq::Fq as BN256Fq;
@@ -26,8 +26,8 @@ type BN256BaseNNField<F> = NonNativeFieldOverU16<F, BN256Fq, 17>;
 type BN256ScalarNNField<F> = NonNativeFieldOverU16<F, BN256Fr, 17>;
 
 // Scalar field extensions for BN256 curve
-type BN256Fp2NNField<F> = Fp2<F, BN256Fq, BN256BaseNNField<F>>;
-type BN256Fp12NNField<F> = Fp12<F, BN256Fq, BN256BaseNNField<F>>;
+type BN256Fp2NNField<F> = Fp2<F, BN256Fq, BN256BaseNNField<F>, BN256Extension2Params>;
+type BN256Fp12NNField<F> = Fp12<F, BN256Fq, BN256BaseNNField<F>, BN256Extension12Params>;
 type BN256Fp2ProjectiveCurvePoint<F> = [BN256Fp2NNField<F>; 3];
 
 fn bn256_base_field_params() -> BN256BaseNNFieldParams {

--- a/src/gadgets/curves/bn256/mod.rs
+++ b/src/gadgets/curves/bn256/mod.rs
@@ -1,9 +1,10 @@
 use super::curves::non_native_field::implementations::{
     NonNativeFieldOverU16, NonNativeFieldOverU16Params,
 };
+use super::sw_projective::extended::ExtendedSWProjectivePoint;
 use super::sw_projective::SWProjectivePoint;
-use super::tower_extension::fp12::Fp12;
-use crate::gadgets::tower_extension::fp2::Fp2;
+use super::tower_extension::fq12::Fq12;
+use crate::gadgets::tower_extension::fq2::Fq2;
 
 // Characteristic of the base field for bn256 curve
 use pairing::bn256::fq::Fq as BN256Fq;
@@ -11,24 +12,38 @@ use pairing::bn256::fq::Fq as BN256Fq;
 use pairing::bn256::fr::Fr as BN256Fr;
 // Affine point for bn256 curve
 use pairing::bn256::G1Affine as BN256Affine;
+use pairing::bn256::G2Affine as BN256AffineTwisted;
 
 pub mod decomp_table;
 pub mod ec_mul;
 pub mod ec_pairing;
 pub mod naf_abs_div2_table;
 
-// 17 bits * 16 bits in u16 = 272 bits > 254 bits used in BN254
+// --- Base and scalar field params for BN256 curve ---
+/// Params of BN256 base field
 type BN256BaseNNFieldParams = NonNativeFieldOverU16Params<BN256Fq, 17>;
+/// Params of BN256 scalar field
 type BN256ScalarNNFieldParams = NonNativeFieldOverU16Params<BN256Fr, 17>;
-
-// Base field and scalar field for BN256 curve
+/// Non-native field over u16 for BN256 base field
 type BN256BaseNNField<F> = NonNativeFieldOverU16<F, BN256Fq, 17>;
+/// Non-native field over u16 for BN256 scalar field
 type BN256ScalarNNField<F> = NonNativeFieldOverU16<F, BN256Fr, 17>;
 
-// Scalar field extensions for BN256 curve
-type BN256Fp2NNField<F> = Fp2<F, BN256Fq, BN256BaseNNField<F>>;
-type BN256Fp12NNField<F> = Fp12<F, BN256Fq, BN256BaseNNField<F>>;
-type BN256Fp2ProjectiveCurvePoint<F> = [BN256Fp2NNField<F>; 3];
+// P.S. we used 17 bits since 17 bits * 16 bits in u16 = 272 bits > 254 bits
+// used in BN254 (so we have some extra space to deal with)
+
+// --- Field extensions for BN256 curve ---
+/// Non-native field extension Fq2 for BN256 curve
+type BN256Fq2NNField<F> = Fq2<F, BN256Fq, BN256BaseNNField<F>>;
+/// Non-native field extension Fq12 for BN256 curve
+type BN256Fq12NNField<F> = Fq12<F, BN256Fq, BN256BaseNNField<F>>;
+
+// --- SW Projective points for BN256 curves: regular and twisted ---
+/// SW Projective point for BN256 curve over non-extended base field
+type BN256SWProjectivePoint<F> = SWProjectivePoint<F, BN256Affine, BN256BaseNNField<F>>;
+/// SW Projective point for twisted BN256 curve over extended base field `Fp2`
+type BN256SWProjectivePointTwisted<F> =
+    ExtendedSWProjectivePoint<F, BN256Fq, BN256AffineTwisted, BN256Fq2NNField<F>>;
 
 fn bn256_base_field_params() -> BN256BaseNNFieldParams {
     NonNativeFieldOverU16Params::create()

--- a/src/gadgets/non_native_field/traits/mod.rs
+++ b/src/gadgets/non_native_field/traits/mod.rs
@@ -1,7 +1,11 @@
 use super::*;
+
 use crate::gadgets::boolean::Boolean;
 use crate::{cs::traits::cs::ConstraintSystem, gadgets::traits::witnessable::WitnessHookable};
+
+use pairing::GenericCurveAffine;
 use std::sync::Arc;
+
 
 pub trait NonNativeField<F: SmallField, T: pairing::ff::PrimeField>:
     'static + Send + Sync + Clone + std::fmt::Debug + WitnessHookable<F>
@@ -77,5 +81,18 @@ pub trait NonNativeField<F: SmallField, T: pairing::ff::PrimeField>:
         flag: Boolean<F>,
         a: &Self,
         b: &Self,
+    ) -> Self;
+}
+
+pub trait CurveCompatibleNonNativeField<
+    F: SmallField,
+    T: pairing::ff::PrimeField,
+    C: GenericCurveAffine,
+>: NonNativeField<F, T>
+{
+    fn from_curve_base<CS: ConstraintSystem<F>>(
+        cs: &mut CS,
+        point: &C::Base,
+        params: &Arc<Self::Params>,
     ) -> Self;
 }

--- a/src/gadgets/tower_extension/fp12.rs
+++ b/src/gadgets/tower_extension/fp12.rs
@@ -2,7 +2,11 @@ use std::sync::Arc;
 
 use pairing::ff::PrimeField;
 
-use super::{fp2::Fp2, fp6::Fp6};
+use super::{
+    fp2::Fp2,
+    fp6::Fp6,
+    params::{Extension12Params, Extension6Params},
+};
 
 use crate::{
     cs::traits::cs::ConstraintSystem,
@@ -15,25 +19,27 @@ use crate::{
 /// linear polynomials in a form `c0+c1*w`, where `c0` and `c1` are elements of `Fp6`.
 /// See https://hackmd.io/@jpw/bn254#Field-extension-towers for reference. For
 /// implementation reference, see https://eprint.iacr.org/2006/471.pdf.
-pub struct Fp12<F, T, NN>
+pub struct Fp12<F, T, NN, P>
 where
     F: SmallField,
     T: PrimeField,
     NN: NonNativeField<F, T>,
+    P: Extension12Params<T>,
 {
-    pub c0: Fp6<F, T, NN>,
-    pub c1: Fp6<F, T, NN>,
+    pub c0: Fp6<F, T, NN, P::Ex6>,
+    pub c1: Fp6<F, T, NN, P::Ex6>,
     _marker: std::marker::PhantomData<(F, T)>,
 }
 
-impl<F, T, NN> Fp12<F, T, NN>
+impl<F, T, NN, P> Fp12<F, T, NN, P>
 where
     F: SmallField,
     T: PrimeField,
     NN: NonNativeField<F, T>,
+    P: Extension12Params<T>,
 {
     /// Creates a new `Fp12` element from two `Fp6` components.
-    pub fn new(c0: Fp6<F, T, NN>, c1: Fp6<F, T, NN>) -> Self {
+    pub fn new(c0: Fp6<F, T, NN, P::Ex6>, c1: Fp6<F, T, NN, P::Ex6>) -> Self {
         Self {
             c0,
             c1,
@@ -162,9 +168,9 @@ where
     pub fn mul_by_c0c1c4<CS>(
         &mut self,
         cs: &mut CS,
-        c0: &mut Fp2<F, T, NN>,
-        c1: &mut Fp2<F, T, NN>,
-        c4: &mut Fp2<F, T, NN>,
+        c0: &mut Fp2<F, T, NN, <<P as Extension12Params<T>>::Ex6 as Extension6Params<T>>::Ex2>,
+        c1: &mut Fp2<F, T, NN, <<P as Extension12Params<T>>::Ex6 as Extension6Params<T>>::Ex2>,
+        c4: &mut Fp2<F, T, NN, <<P as Extension12Params<T>>::Ex6 as Extension6Params<T>>::Ex2>,
     ) -> Self
     where
         CS: ConstraintSystem<F>,
@@ -180,6 +186,28 @@ where
 
         let mut c0 = bb.mul_by_nonresidue(cs);
         let c0 = c0.add(cs, &mut aa);
+
+        Self::new(c0, c1)
+    }
+
+    /// Compute the Frobenius map - raise this element to power.
+    pub fn frobenius_map<CS>(&mut self, cs: &mut CS, power: usize) -> Self
+    where
+        CS: ConstraintSystem<F>,
+    {
+        // TODO: explain:
+
+        match power {
+            1 | 2 | 3 | 6 => {}
+            _ => {
+                unreachable!("can not reach power {}", power);
+            }
+        }
+
+        let c0 = self.c0.frobenius_map(cs, power);
+        let c1 = self.c1.frobenius_map(cs, power);
+
+        // TODO: add frobenius map of c1 Fp6 to its corresponding c0, c1, c2 FROBENIUS_COEFFS.
 
         Self::new(c0, c1)
     }

--- a/src/gadgets/tower_extension/fq12.rs
+++ b/src/gadgets/tower_extension/fq12.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use pairing::ff::PrimeField;
 
-use super::{fp2::Fp2, fp6::Fp6};
+use super::{fq2::Fq2, fq6::Fq6};
 
 use crate::{
     cs::traits::cs::ConstraintSystem,
@@ -10,30 +10,30 @@ use crate::{
     gadgets::{boolean::Boolean, non_native_field::traits::NonNativeField},
 };
 
-/// `Fp12` field extension implementation in the constraint system. It is implemented
-/// as `Fp6[w]/(w^2-v)` where `w^6=9+u`. In other words, it is a set of
-/// linear polynomials in a form `c0+c1*w`, where `c0` and `c1` are elements of `Fp6`.
+/// `Fq12` field extension implementation in the constraint system. It is implemented
+/// as `Fq6[w]/(w^2-v)` where `w^6=9+u`. In other words, it is a set of
+/// linear polynomials in a form `c0+c1*w`, where `c0` and `c1` are elements of `Fq6`.
 /// See https://hackmd.io/@jpw/bn254#Field-extension-towers for reference. For
 /// implementation reference, see https://eprint.iacr.org/2006/471.pdf.
-pub struct Fp12<F, T, NN>
+pub struct Fq12<F, T, NN>
 where
     F: SmallField,
     T: PrimeField,
     NN: NonNativeField<F, T>,
 {
-    pub c0: Fp6<F, T, NN>,
-    pub c1: Fp6<F, T, NN>,
+    pub c0: Fq6<F, T, NN>,
+    pub c1: Fq6<F, T, NN>,
     _marker: std::marker::PhantomData<(F, T)>,
 }
 
-impl<F, T, NN> Fp12<F, T, NN>
+impl<F, T, NN> Fq12<F, T, NN>
 where
     F: SmallField,
     T: PrimeField,
     NN: NonNativeField<F, T>,
 {
-    /// Creates a new `Fp12` element from two `Fp6` components.
-    pub fn new(c0: Fp6<F, T, NN>, c1: Fp6<F, T, NN>) -> Self {
+    /// Creates a new `Fq12` element from two `Fq6` components.
+    pub fn new(c0: Fq6<F, T, NN>, c1: Fq6<F, T, NN>) -> Self {
         Self {
             c0,
             c1,
@@ -41,26 +41,26 @@ where
         }
     }
 
-    /// Creates a new zero `Fp12` in a form `0+0*w`
+    /// Creates a new zero `Fq12` in a form `0+0*w`
     pub fn zero<CS>(cs: &mut CS, params: &Arc<NN::Params>) -> Self
     where
         CS: ConstraintSystem<F>,
     {
-        let zero = Fp6::zero(cs, params);
+        let zero = Fq6::zero(cs, params);
         Self::new(zero.clone(), zero)
     }
 
-    /// Creates a unit `Fp12` in a form `1+0*w`
+    /// Creates a unit `Fq12` in a form `1+0*w`
     pub fn one<CS>(cs: &mut CS, params: &Arc<NN::Params>) -> Self
     where
         CS: ConstraintSystem<F>,
     {
-        let one = Fp6::one(cs, params);
-        let zero = Fp6::zero(cs, params);
+        let one = Fq6::one(cs, params);
+        let zero = Fq6::zero(cs, params);
         Self::new(one, zero)
     }
 
-    /// Returns true if the `Fp12` element is zero.
+    /// Returns true if the `Fq12` element is zero.
     pub fn is_zero<CS>(&mut self, cs: &mut CS) -> Boolean<F>
     where
         CS: ConstraintSystem<F>,
@@ -70,7 +70,7 @@ where
         is_c0_zero.and(cs, is_c1_zero)
     }
 
-    /// Conjugates the `Fp12` element by negating the `c1` component.
+    /// Conjugates the `Fq12` element by negating the `c1` component.
     pub fn conjugate<CS>(&mut self, cs: &mut CS) -> Self
     where
         CS: ConstraintSystem<F>,
@@ -162,9 +162,9 @@ where
     pub fn mul_by_c0c1c4<CS>(
         &mut self,
         cs: &mut CS,
-        c0: &mut Fp2<F, T, NN>,
-        c1: &mut Fp2<F, T, NN>,
-        c4: &mut Fp2<F, T, NN>,
+        c0: &mut Fq2<F, T, NN>,
+        c1: &mut Fq2<F, T, NN>,
+        c4: &mut Fq2<F, T, NN>,
     ) -> Self
     where
         CS: ConstraintSystem<F>,

--- a/src/gadgets/tower_extension/fq12.rs
+++ b/src/gadgets/tower_extension/fq12.rs
@@ -48,6 +48,7 @@ where
         }
     }
 
+    #[allow(unused_variables)]
     pub fn pow<CS>(&mut self, cs: &mut CS, exponent: T) -> Self
     where
         CS: ConstraintSystem<F>,
@@ -198,6 +199,25 @@ where
         Self::new(c0, c1)
     }
 
+    pub fn mul_by_c0c3c4<CS>(
+        &mut self,
+        cs: &mut CS,
+        c0: &mut Fq2<F, T, NN, <<P as Extension12Params<T>>::Ex6 as Extension6Params<T>>::Ex2>,
+        c3: &mut Fq2<F, T, NN, <<P as Extension12Params<T>>::Ex6 as Extension6Params<T>>::Ex2>,
+        c4: &mut Fq2<F, T, NN, <<P as Extension12Params<T>>::Ex6 as Extension6Params<T>>::Ex2>,
+    ) -> Self 
+    where 
+        CS: ConstraintSystem<F>,
+    {
+        let zero = Fq2::zero(cs, &c0.c0.get_params());
+        let c0 = Fq6::new(c0.clone(), zero.clone(), zero.clone());
+        let c1 = Fq6::new(c3.clone(), c4.clone(), zero);
+        let mut other = Fq12::new(c0, c1);
+
+        // TODO: make it hand optimized
+        self.mul(cs, &mut other)
+    }
+
     /// Compute the Frobenius map - raise this element to power.
     pub fn frobenius_map<CS>(&mut self, cs: &mut CS, power: usize) -> Self
     where
@@ -220,6 +240,7 @@ where
         Self::new(c0, c1)
     }
 
+    #[allow(unused_variables)]
     pub fn inverse<CS>(&mut self, cs: &mut CS) -> Self
     where
         CS: ConstraintSystem<F>,

--- a/src/gadgets/tower_extension/fq12.rs
+++ b/src/gadgets/tower_extension/fq12.rs
@@ -48,6 +48,13 @@ where
         }
     }
 
+    pub fn pow<CS>(&mut self, cs: &mut CS, exponent: T) -> Self
+    where
+        CS: ConstraintSystem<F>,
+    {
+        todo!();
+    }
+
     /// Creates a new zero `Fq12` in a form `0+0*w`
     pub fn zero<CS>(cs: &mut CS, params: &Arc<NN::Params>) -> Self
     where

--- a/src/gadgets/tower_extension/fq12.rs
+++ b/src/gadgets/tower_extension/fq12.rs
@@ -19,6 +19,7 @@ use crate::{
 /// linear polynomials in a form `c0+c1*w`, where `c0` and `c1` are elements of `Fq6`.
 /// See https://hackmd.io/@jpw/bn254#Field-extension-towers for reference. For
 /// implementation reference, see https://eprint.iacr.org/2006/471.pdf.
+#[derive(Clone, Copy)]
 pub struct Fq12<F, T, NN, P>
 where
     F: SmallField,
@@ -210,5 +211,12 @@ where
         // TODO: add frobenius map of c1 Fp6 to its corresponding c0, c1, c2 FROBENIUS_COEFFS.
 
         Self::new(c0, c1)
+    }
+
+    pub fn inverse<CS>(&mut self, cs: &mut CS) -> Self
+    where
+        CS: ConstraintSystem<F>,
+    {
+        todo!();
     }
 }

--- a/src/gadgets/tower_extension/fq6.rs
+++ b/src/gadgets/tower_extension/fq6.rs
@@ -2,7 +2,7 @@ use std::{mem, sync::Arc};
 
 use pairing::ff::PrimeField;
 
-use super::fp2::Fp2;
+use super::fq2::Fq2;
 
 use crate::{
     cs::traits::cs::ConstraintSystem,
@@ -10,33 +10,33 @@ use crate::{
     gadgets::{boolean::Boolean, non_native_field::traits::NonNativeField},
 };
 
-/// `Fp6` field extension implementation in the constraint system. It is implemented
-/// as `Fp2[v]/(v^3-xi)` where `xi=9+u`. In other words,
+/// `Fq6` field extension implementation in the constraint system. It is implemented
+/// as `Fq2[v]/(v^3-xi)` where `xi=9+u`. In other words,
 /// it is a set of quadratic polynomials of a form `c0+c1*v+c2*v^2`,
-///  where `c0`, `c1`, `c2` are elements of `Fp2`.
+///  where `c0`, `c1`, `c2` are elements of `Fq2`.
 /// See https://hackmd.io/@jpw/bn254#Field-extension-towers for reference. For
 /// implementation reference, see https://eprint.iacr.org/2006/471.pdf.
 #[derive(Clone, Debug, Copy)]
-pub struct Fp6<F, T, NN>
+pub struct Fq6<F, T, NN>
 where
     F: SmallField,
     T: PrimeField,
     NN: NonNativeField<F, T>,
 {
-    pub c0: Fp2<F, T, NN>,
-    pub c1: Fp2<F, T, NN>,
-    pub c2: Fp2<F, T, NN>,
+    pub c0: Fq2<F, T, NN>,
+    pub c1: Fq2<F, T, NN>,
+    pub c2: Fq2<F, T, NN>,
     _marker: std::marker::PhantomData<(F, T)>,
 }
 
-impl<F, T, NN> Fp6<F, T, NN>
+impl<F, T, NN> Fq6<F, T, NN>
 where
     F: SmallField,
     T: pairing::ff::PrimeField,
     NN: NonNativeField<F, T>,
 {
-    /// Creates a new `Fp6` element from three `Fp2` components.
-    pub fn new(c0: Fp2<F, T, NN>, c1: Fp2<F, T, NN>, c2: Fp2<F, T, NN>) -> Self {
+    /// Creates a new `Fq6` element from three `Fq2` components.
+    pub fn new(c0: Fq2<F, T, NN>, c1: Fq2<F, T, NN>, c2: Fq2<F, T, NN>) -> Self {
         Self {
             c0,
             c1,
@@ -45,26 +45,26 @@ where
         }
     }
 
-    /// Creates a new zero `Fp6` in a form `0+0*v+0*v^2`
+    /// Creates a new zero `Fq6` in a form `0+0*v+0*v^2`
     pub fn zero<CS>(cs: &mut CS, params: &Arc<NN::Params>) -> Self
     where
         CS: ConstraintSystem<F>,
     {
-        let zero = Fp2::zero(cs, params);
+        let zero = Fq2::zero(cs, params);
         Self::new(zero.clone(), zero.clone(), zero)
     }
 
-    /// Creates a unit `Fp6` in a form `1+0*v+0*v^2`
+    /// Creates a unit `Fq6` in a form `1+0*v+0*v^2`
     pub fn one<CS>(cs: &mut CS, params: &Arc<NN::Params>) -> Self
     where
         CS: ConstraintSystem<F>,
     {
-        let one = Fp2::one(cs, params);
-        let zero = Fp2::zero(cs, params);
+        let one = Fq2::one(cs, params);
+        let zero = Fq2::zero(cs, params);
         Self::new(one, zero.clone(), zero)
     }
 
-    /// Returns true if the `Fp6` element is zero.
+    /// Returns true if the `Fq6` element is zero.
     pub fn is_zero<CS>(&mut self, cs: &mut CS) -> Boolean<F>
     where
         CS: ConstraintSystem<F>,
@@ -75,7 +75,7 @@ where
         is_c0_zero.and(cs, is_c1_zero).and(cs, is_c2_zero)
     }
 
-    /// Adds two elements of `Fp6` by adding their components elementwise.
+    /// Adds two elements of `Fq6` by adding their components elementwise.
     #[must_use]
     pub fn add<CS>(&mut self, cs: &mut CS, other: &mut Self) -> Self
     where
@@ -87,7 +87,7 @@ where
         Self::new(c0, c1, c2)
     }
 
-    /// Doubles the element of `Fp6` by doubling its components.
+    /// Doubles the element of `Fq6` by doubling its components.
     #[must_use]
     pub fn double<CS>(&mut self, cs: &mut CS) -> Self
     where
@@ -99,7 +99,7 @@ where
         Self::new(c0, c1, c2)
     }
 
-    /// Negates the element of `Fp6` by negating its components.
+    /// Negates the element of `Fq6` by negating its components.
     #[must_use]
     pub fn negated<CS>(&mut self, cs: &mut CS) -> Self
     where
@@ -111,7 +111,7 @@ where
         Self::new(c0, c1, c2)
     }
 
-    /// Subtracts two elements of `Fp6` by subtracting their components elementwise.
+    /// Subtracts two elements of `Fq6` by subtracting their components elementwise.
     #[must_use]
     pub fn sub<CS>(&mut self, cs: &mut CS, other: &mut Self) -> Self
     where
@@ -123,7 +123,7 @@ where
         Self::new(c0, c1, c2)
     }
 
-    /// Multiplies the element in `Fp6` by a non-residue `xi=9+u`.
+    /// Multiplies the element in `Fq6` by a non-residue `xi=9+u`.
     pub fn mul_by_nonresidue<CS>(&mut self, cs: &mut CS) -> Self
     where
         CS: ConstraintSystem<F>,
@@ -137,7 +137,7 @@ where
     }
 
     /// Multiplies two elements `a=a0+a1*v+a2*v^2`
-    /// and `b=b0+b1*v+b2*v^2` in `Fp6` using Karatsuba multiplication.
+    /// and `b=b0+b1*v+b2*v^2` in `Fq6` using Karatsuba multiplication.
     #[must_use]
     pub fn mul<CS>(&mut self, cs: &mut CS, other: &mut Self) -> Self
     where
@@ -177,7 +177,7 @@ where
         Self::new(c0, c1, c2)
     }
 
-    /// Squares the element `a=a0+a1*v+a2*v^2` in `Fp6` using Karatsuba squaring.
+    /// Squares the element `a=a0+a1*v+a2*v^2` in `Fq6` using Karatsuba squaring.
     #[must_use]
     pub fn square<CS: ConstraintSystem<F>>(&mut self, cs: &mut CS) -> Self {
         // v0 <- a0^2, v1 <- a1^2, v2 <- a2^2
@@ -211,8 +211,8 @@ where
         Self::new(c0, c1, c2)
     }
 
-    /// Multiplies the element `a=a0+a1*v+a2*v^2` in `Fp6` by the element `b = b1*v`
-    pub fn mul_by_c1<CS>(&mut self, cs: &mut CS, c1: &mut Fp2<F, T, NN>) -> Self
+    /// Multiplies the element `a=a0+a1*v+a2*v^2` in `Fq6` by the element `b = b1*v`
+    pub fn mul_by_c1<CS>(&mut self, cs: &mut CS, c1: &mut Fq2<F, T, NN>) -> Self
     where
         CS: ConstraintSystem<F>,
     {
@@ -230,12 +230,12 @@ where
         Self::new(t1, t2, b_b)
     }
 
-    /// Multiplies the element `a=a0+a1*v+a2*v^2` in `Fp6` by the element `b = b0+b1*v`
+    /// Multiplies the element `a=a0+a1*v+a2*v^2` in `Fq6` by the element `b = b0+b1*v`
     pub fn mul_by_c0c1<CS>(
         &mut self,
         cs: &mut CS,
-        c0: &mut Fp2<F, T, NN>,
-        c1: &mut Fp2<F, T, NN>,
+        c0: &mut Fq2<F, T, NN>,
+        c1: &mut Fq2<F, T, NN>,
     ) -> Self
     where
         CS: ConstraintSystem<F>,

--- a/src/gadgets/tower_extension/fq6.rs
+++ b/src/gadgets/tower_extension/fq6.rs
@@ -270,6 +270,7 @@ where
     }
 
     /// Compute the Frobenius map - raise this element to power.
+    #[allow(unused_variables)]
     pub fn frobenius_map<CS>(&mut self, cs: &mut CS, power: usize) -> Self
     where
         CS: ConstraintSystem<F>,
@@ -284,8 +285,8 @@ where
         }
 
         let c0 = self.c0.frobenius_map(cs, power);
-        let mut c1 = self.c1.frobenius_map(cs, power);
-        let mut c2 = self.c2.frobenius_map(cs, power);
+        let c1 = self.c1.frobenius_map(cs, power);
+        let c2 = self.c2.frobenius_map(cs, power);
 
         // TODO: add multiplication of c1 and c2 by corresponding FROBENIUS_COEFFS c1 and c2.
         // TODO: assert what Fq2 under CS computes frobenius map same as without CS.

--- a/src/gadgets/tower_extension/mod.rs
+++ b/src/gadgets/tower_extension/mod.rs
@@ -1,3 +1,4 @@
 pub mod fp12;
 pub mod fp2;
 pub mod fp6;
+pub mod params;

--- a/src/gadgets/tower_extension/mod.rs
+++ b/src/gadgets/tower_extension/mod.rs
@@ -1,3 +1,3 @@
-pub mod fp12;
-pub mod fp2;
-pub mod fp6;
+pub mod fq12;
+pub mod fq2;
+pub mod fq6;

--- a/src/gadgets/tower_extension/params/bn256.rs
+++ b/src/gadgets/tower_extension/params/bn256.rs
@@ -1,0 +1,37 @@
+use pairing::bn256::{fq::Fq as BN256Fq, Fq12 as BN256Fq12, Fq2 as BN256Fq2, Fq6 as BN256Fq6};
+
+use pairing::bn256::fq::{
+    FROBENIUS_COEFF_FQ12_C1 as BN256_FROBENIUS_COEFF_FQ12_C1,
+    FROBENIUS_COEFF_FQ6_C1 as BN256_FROBENIUS_COEFF_FQ6_C1,
+    FROBENIUS_COEFF_FQ6_C2 as BN256_FROBENIUS_COEFF_FQ6_C2,
+};
+
+use super::*;
+
+#[derive(Clone)]
+pub struct BN256Extension2Params {}
+impl Extension2Params<BN256Fq> for BN256Extension2Params {
+    type Witness = BN256Fq2;
+}
+
+#[derive(Clone)]
+pub struct BN256Extension6Params {}
+impl Extension6Params<BN256Fq> for BN256Extension6Params {
+    type Ex2 = BN256Extension2Params;
+    type Witness = BN256Fq6;
+
+    const FROBENIUS_COEFFS_C1: [BN256Fq2; 6] = BN256_FROBENIUS_COEFF_FQ6_C1;
+    const FROBENIUS_COEFFS_C2: [BN256Fq2; 6] = BN256_FROBENIUS_COEFF_FQ6_C2;
+}
+
+#[derive(Clone)]
+pub struct BN256Extension12Params {}
+impl Extension12Params<BN256Fq> for BN256Extension12Params {
+    type Ex6 = BN256Extension6Params;
+    type Witness = BN256Fq12;
+
+    // These are Fp2 because we will multiply them with c1 `Fp6`, which has underlying `Fp2`.
+    const FROBENIUS_COEFFS_C1:
+        [<<Self::Ex6 as Extension6Params<BN256Fq>>::Ex2 as Extension2Params<BN256Fq>>::Witness; 12] =
+        BN256_FROBENIUS_COEFF_FQ12_C1;
+}

--- a/src/gadgets/tower_extension/params/bn256.rs
+++ b/src/gadgets/tower_extension/params/bn256.rs
@@ -8,13 +8,13 @@ use pairing::bn256::fq::{
 
 use super::*;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Copy)]
 pub struct BN256Extension2Params {}
 impl Extension2Params<BN256Fq> for BN256Extension2Params {
     type Witness = BN256Fq2;
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct BN256Extension6Params {}
 impl Extension6Params<BN256Fq> for BN256Extension6Params {
     type Ex2 = BN256Extension2Params;
@@ -24,7 +24,7 @@ impl Extension6Params<BN256Fq> for BN256Extension6Params {
     const FROBENIUS_COEFFS_C2: [BN256Fq2; 6] = BN256_FROBENIUS_COEFF_FQ6_C2;
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct BN256Extension12Params {}
 impl Extension12Params<BN256Fq> for BN256Extension12Params {
     type Ex6 = BN256Extension6Params;

--- a/src/gadgets/tower_extension/params/mod.rs
+++ b/src/gadgets/tower_extension/params/mod.rs
@@ -6,12 +6,12 @@ pub mod bn256;
 // Besides, one may include here field-specific characteristics, such as non-residue for example,
 // and branch out implementations with the help of it.
 
-pub trait Extension2Params<P: PrimeField>: Clone {
+pub trait Extension2Params<P: PrimeField>: Clone + Copy {
     /// Witness here represents field element not under CS.
     type Witness: Field;
 }
 
-pub trait Extension6Params<P: PrimeField>: Clone {
+pub trait Extension6Params<P: PrimeField>: Clone + Copy {
     type Ex2: Extension2Params<P>;
     /// Witness here represents field element not under CS.
     type Witness: Field;
@@ -20,7 +20,7 @@ pub trait Extension6Params<P: PrimeField>: Clone {
     const FROBENIUS_COEFFS_C2: [<Self::Ex2 as Extension2Params<P>>::Witness; 6];
 }
 
-pub trait Extension12Params<P: PrimeField>: Clone {
+pub trait Extension12Params<P: PrimeField>: Clone + Copy {
     type Ex6: Extension6Params<P>;
     /// Witness here represents field element not under CS.
     type Witness: Field;

--- a/src/gadgets/tower_extension/params/mod.rs
+++ b/src/gadgets/tower_extension/params/mod.rs
@@ -1,0 +1,31 @@
+use pairing::ff::{Field, PrimeField};
+
+pub mod bn256;
+
+// We don't have generic unconstrained tower extensions element, so we resolve it using following.
+// Besides, one may include here field-specific characteristics, such as non-residue for example,
+// and branch out implementations with the help of it.
+
+pub trait Extension2Params<P: PrimeField>: Clone {
+    /// Witness here represents field element not under CS.
+    type Witness: Field;
+}
+
+pub trait Extension6Params<P: PrimeField>: Clone {
+    type Ex2: Extension2Params<P>;
+    /// Witness here represents field element not under CS.
+    type Witness: Field;
+
+    const FROBENIUS_COEFFS_C1: [<Self::Ex2 as Extension2Params<P>>::Witness; 6];
+    const FROBENIUS_COEFFS_C2: [<Self::Ex2 as Extension2Params<P>>::Witness; 6];
+}
+
+pub trait Extension12Params<P: PrimeField>: Clone {
+    type Ex6: Extension6Params<P>;
+    /// Witness here represents field element not under CS.
+    type Witness: Field;
+
+    const FROBENIUS_COEFFS_C1: [<<Self::Ex6 as Extension6Params<P>>::Ex2 as Extension2Params<
+        P,
+    >>::Witness; 12];
+}


### PR DESCRIPTION
# What ❔

This pull request adds tower extension implementation for fields 

$$
\mathbb{F}_{p^2} \mapsto \mathbb{F}\_{p^6} \mapsto \mathbb{F}\_{p^{12}}
$$

It adds `NonNativeField<F, T>` implementation for $\mathbb{F}_{p^2}$ struct and implements most basic operations over $\mathbb{F}\_{p^6}$ and $\mathbb{F}\_{p^{12}}$.

## Why ❔

EC Pairing heavily relies on exploiting standard field extension $\mathbb{F}_p$. Although the standard field is already convered in the codebase, the fields extensions cannot be easily managed currently.

## Checklist
- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
